### PR TITLE
docs(readme): Comply new policies INTER-276

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Fingerprint Pro Angular SDK is an easy way to integrate  **[Fingerprint Pro](htt
 
 The following dependencies are required:
 
-- TypeScript >=4.6 and <= 5.2
+- TypeScript >=4.6
 - Node 16+
 - Angular 13+
 - RxJS 7.5+

--- a/README.md
+++ b/README.md
@@ -52,7 +52,6 @@ The following dependencies are required:
 - TypeScript >=4.6
 - Node 16+
 - Angular 13+
-- RxJS 7.5+
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Fingerprint Pro Angular SDK is an easy way to integrate  **[Fingerprint Pro](htt
 
 The following dependencies are required:
 
-- TypeScript 4
+- TypeScript >=4.6 and <= 5.2
 - Node 16+
 - Angular 13+
 - RxJS 7.5+

--- a/README.md
+++ b/README.md
@@ -37,12 +37,22 @@ Fingerprint Pro Angular SDK is an easy way to integrate  **[Fingerprint Pro](htt
 
 ## Table of contents
 
+- [Requirements](#requirements)
 - [Installation](#installation)
 - [Getting started](#getting-started)
 - [Caching strategy](#caching-strategy)
 - [Documentation](#documentation)
 - [Support and feedback](#support-and-feedback)
 - [License](#license)
+
+## Requirements
+
+The following dependencies are required:
+
+- TypeScript 4
+- Node 16+
+- Angular 13+
+- RxJS 7.5+
 
 ## Installation
 


### PR DESCRIPTION
This integration works for Angular version between 13 and 17 (latest)
Angular 17 only works with Typescript >=4.9.3 <5.3.0. So it doesn't supports Typescript 5.3.0 or 5.3.3.
I updated our libraries requirements as:

```
- TypeScript >=4.6
- Angular 13+
```
CC: @JuroUhlar @ilfa