### PR TITLE
Update @fingerprintjs/fingerprintjs-pro-spa Dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "@angular/platform-browser-dynamic": "^15.2.10",
     "@angular/platform-server": "^15.2.10",
     "@angular/router": "^15.2.10",
-    "@fingerprintjs/fingerprintjs-pro-spa": "^1.3.1",
+    "@fingerprintjs/fingerprintjs-pro-spa": "^1.3.2",
     "@nguniversal/express-engine": "^15.2.1",
     "express": "^4.20.0",
     "rxjs": "~7.5.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -36,8 +36,8 @@ importers:
         specifier: ^15.2.10
         version: 15.2.10(@angular/common@15.2.10(@angular/core@15.2.10(rxjs@7.5.7)(zone.js@0.11.5))(rxjs@7.5.7))(@angular/core@15.2.10(rxjs@7.5.7)(zone.js@0.11.5))(@angular/platform-browser@15.2.10(@angular/animations@15.2.10(@angular/core@15.2.10(rxjs@7.5.7)(zone.js@0.11.5)))(@angular/common@15.2.10(@angular/core@15.2.10(rxjs@7.5.7)(zone.js@0.11.5))(rxjs@7.5.7))(@angular/core@15.2.10(rxjs@7.5.7)(zone.js@0.11.5)))(rxjs@7.5.7)
       '@fingerprintjs/fingerprintjs-pro-spa':
-        specifier: ^1.3.1
-        version: 1.3.1
+        specifier: ^1.3.2
+        version: 1.3.2
       '@nguniversal/express-engine':
         specifier: ^15.2.1
         version: 15.2.1(@angular/common@15.2.10(@angular/core@15.2.10(rxjs@7.5.7)(zone.js@0.11.5))(rxjs@7.5.7))(@angular/core@15.2.10(rxjs@7.5.7)(zone.js@0.11.5))(@angular/platform-server@15.2.10(ilc5b3yotbseevm3xgvvpgxpgm))(express@4.20.0)
@@ -1319,8 +1319,11 @@ packages:
   '@fingerprintjs/fingerprintjs-pro-spa@1.3.0':
     resolution: {integrity: sha512-XNZiA9kyuzfBZtCCr7B4x24pkp7WCpxzjAQbH87Iq89yWn48Auxc8Xh4a5q2Bpj9velFp1cdp76h3C0KaUsdwQ==}
 
-  '@fingerprintjs/fingerprintjs-pro-spa@1.3.1':
-    resolution: {integrity: sha512-1k+85IYh1bBDJY/syHzBmTzKKaPGQkpq8GO9+vf7MHdqlmIiLAcutaHMUXey9DxylKm93qCHRY/1fCOOQ/LiTA==}
+  '@fingerprintjs/fingerprintjs-pro-spa@1.3.2':
+    resolution: {integrity: sha512-s1YGsx1XQLmjU+av4UrUHNxyzwPHyZRB0GXJQFOJK8ZHCYc2SNukxnJmZA++bNBa8twU3wW+QgSJhA4Prjnd0g==}
+
+  '@fingerprintjs/fingerprintjs-pro@3.11.5':
+    resolution: {integrity: sha512-Yn3E/nAE1udXQkNGJS7/jmlY3zUXDFXA4V32odMZ3vCAXb7kYnqHn62YMJ5jOa9NVVzicmDudiywLUtxUZU9PA==}
 
   '@fingerprintjs/fingerprintjs-pro@3.9.2':
     resolution: {integrity: sha512-H8CkfBp8LAfH8m7QU/BWvn+wBew6PWwN7SpChw7nTQfuDDzd7RtUGmF/O1b00Url6/MmGRsOM6bjZUrH8N49BA==}
@@ -2009,6 +2012,7 @@ packages:
 
   acorn-import-assertions@1.8.0:
     resolution: {integrity: sha512-m7VZ3jwz4eK6A4Vtt8Ew1/mNbP24u0FhdyfA7fSvnJR6LMdfOYnmuIrrJAgrYfYJ10F/otaHTtrtrtmHdMNzEw==}
+    deprecated: package has been renamed to acorn-import-attributes
     peerDependencies:
       acorn: ^8
 
@@ -3061,6 +3065,7 @@ packages:
   eslint@8.56.0:
     resolution: {integrity: sha512-Go19xM6T9puCOWntie1/P997aXxFsOi37JIHRWI514Hc6ZnaHGKY9xFhrU65RT6CcBEzZoGG1e6Nq+DT04ZtZQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    deprecated: This version is no longer supported. Please see https://eslint.org/version-support for other options.
     hasBin: true
 
   espree@9.6.1:
@@ -5665,6 +5670,9 @@ packages:
   tslib@2.6.2:
     resolution: {integrity: sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==}
 
+  tslib@2.8.1:
+    resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
   tsutils@3.21.0:
     resolution: {integrity: sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==}
     engines: {node: '>= 6'}
@@ -7338,7 +7346,7 @@ snapshots:
       '@types/node': 14.18.33
       chalk: 4.1.2
       cosmiconfig: 7.0.1
-      cosmiconfig-typescript-loader: 4.2.0(@types/node@14.18.33)(cosmiconfig@7.0.1)(ts-node@10.9.1(@types/node@14.18.33)(typescript@4.9.5))(typescript@4.9.5)
+      cosmiconfig-typescript-loader: 4.2.0(@types/node@14.18.33)(cosmiconfig@7.0.1)(ts-node@10.9.1(@types/node@12.20.52)(typescript@4.9.5))(typescript@4.9.5)
       lodash: 4.17.21
       resolve-from: 5.0.0
       ts-node: 10.9.1(@types/node@14.18.33)(typescript@4.9.5)
@@ -7577,10 +7585,14 @@ snapshots:
       '@fingerprintjs/fingerprintjs-pro': 3.9.2
       tslib: 2.6.2
 
-  '@fingerprintjs/fingerprintjs-pro-spa@1.3.1':
+  '@fingerprintjs/fingerprintjs-pro-spa@1.3.2':
     dependencies:
-      '@fingerprintjs/fingerprintjs-pro': 3.9.2
-      tslib: 2.6.2
+      '@fingerprintjs/fingerprintjs-pro': 3.11.5
+      tslib: 2.8.1
+
+  '@fingerprintjs/fingerprintjs-pro@3.11.5':
+    dependencies:
+      tslib: 2.8.1
 
   '@fingerprintjs/fingerprintjs-pro@3.9.2':
     dependencies:
@@ -9334,7 +9346,7 @@ snapshots:
       object-assign: 4.1.1
       vary: 1.1.2
 
-  cosmiconfig-typescript-loader@4.2.0(@types/node@14.18.33)(cosmiconfig@7.0.1)(ts-node@10.9.1(@types/node@14.18.33)(typescript@4.9.5))(typescript@4.9.5):
+  cosmiconfig-typescript-loader@4.2.0(@types/node@14.18.33)(cosmiconfig@7.0.1)(ts-node@10.9.1(@types/node@12.20.52)(typescript@4.9.5))(typescript@4.9.5):
     dependencies:
       '@types/node': 14.18.33
       cosmiconfig: 7.0.1
@@ -12913,6 +12925,8 @@ snapshots:
   tslib@2.5.0: {}
 
   tslib@2.6.2: {}
+
+  tslib@2.8.1: {}
 
   tsutils@3.21.0(typescript@4.9.5):
     dependencies:


### PR DESCRIPTION
Updates `@fingerprintjs/fingerprintjs-pro-spa` dependency version identifier to `^1.3.2`. It also updates the underlying `@fingerprintjs/fingerprintjs-pro` dependency to `^3.11.0`.