### PR TITLE
Put `tslib` back into dependencies

### DIFF
--- a/.changeset/blue-melons-repeat.md
+++ b/.changeset/blue-melons-repeat.md
@@ -1,0 +1,5 @@
+---
+'@fingerprint/angular': patch
+---
+
+Put `tslib` back into dependencies as `ng-packagr` adds it as a part of the build

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -153,6 +153,9 @@ importers:
       '@fingerprint/agent':
         specifier: ^4.0.0
         version: 4.0.3
+      tslib:
+        specifier: ^2.5.0
+        version: 2.6.2
     publishDirectory: ../../dist/fingerprintjs-pro-angular
 
 packages:

--- a/projects/fingerprintjs-pro-angular/package.json
+++ b/projects/fingerprintjs-pro-angular/package.json
@@ -35,6 +35,7 @@
     "@angular/core": ">=15.0.0"
   },
   "dependencies": {
-    "@fingerprint/agent": "^4.0.0"
+    "@fingerprint/agent": "^4.0.0",
+    "tslib": "^2.5.0"
   }
 }


### PR DESCRIPTION
It is impossible to remove `tslib` (https://github.com/fingerprintjs/angular/pull/92)  as it is being added by `ng-packagr` https://github.com/ng-packagr/ng-packagr/issues/1159.